### PR TITLE
Fixed hard-coded problem #4

### DIFF
--- a/init-loader.el
+++ b/init-loader.el
@@ -50,9 +50,9 @@
 
 (defcustom init-loader-directory
   (expand-file-name (concat (if (boundp 'user-emacs-directory)
-                                user-emacs-directory
+                                (file-name-as-directory user-emacs-directory)
                               "~/.emacs.d/")
-                            "/inits"))
+                            "inits"))
   "inits directory"
   :type 'directory
   :group 'init-loader)


### PR DESCRIPTION
```
Use 'user-emacs-directory'. But this variable was introduced from Emacs23.
So first check that it is bounded.
```

こんな感じでいいですかね。`user-emacs-directory`は  Emacs 23で導入された
ようなので、auto-completeと同じ対応をしてみました。
