### PR TITLE
Fix for daemon mode on Cocoa Emacs

### DIFF
--- a/init-loader.el
+++ b/init-loader.el
@@ -143,7 +143,8 @@ example, 00_foo.el, 01_bar.el ... 99_keybinds.el."
 ;;;###autoload
 (defun* init-loader-load (&optional (init-dir init-loader-directory))
   "Load configuration files in INIT-DIR."
-  (let ((init-dir (init-loader-follow-symlink init-dir)))
+  (let ((init-dir (init-loader-follow-symlink init-dir))
+        (is-carbon-emacs nil))
     (assert (and (stringp init-dir) (file-directory-p init-dir)))
     (init-loader-re-load init-loader-default-regexp init-dir t)
 
@@ -156,9 +157,13 @@ example, 00_foo.el, 01_bar.el ... 99_keybinds.el."
 
     ;; Carbon Emacs
     (when (featurep 'carbon-emacs-package)
-      (init-loader-re-load init-loader-carbon-emacs-regexp init-dir))
+      (init-loader-re-load init-loader-carbon-emacs-regexp init-dir)
+      (setq is-carbon-emacs t))
     ;; Cocoa Emacs
-    (when (equal window-system 'ns)
+    (when (or (equal window-system 'ns)
+              (and (not is-carbon-emacs) ;; for daemon mode
+                   (not window-system)
+                   (eq system-type 'darwin)))
       (init-loader-re-load init-loader-cocoa-emacs-regexp init-dir))
 
     ;; GNU Linux


### PR DESCRIPTION
Original code decides whether this emacs is Cocoa Emacs by value of
window-system is `ns` or not. But daemon mode is enabled, value of
window-system is nil so init-load.el makes wrong a decision.

So I added new conditions.
- This emacs is not carbon Emacs.
- window-system is nil
- system-type is 'darwin

Its emacs is Cocoa Emacs if all conditions are met.

This fixes #13
