### PR TITLE
Call init-loader-show-log only when init-loader-show-log-after-init is t

### DIFF
--- a/init-loader.el
+++ b/init-loader.el
@@ -179,7 +179,7 @@ example, 00_foo.el, 01_bar.el ... 99_keybinds.el."
 
     (case init-loader-show-log-after-init
       (error-only (add-hook 'after-init-hook 'init-loader--show-log-error-only))
-      (t (add-hook 'after-init-hook 'init-loader-show-log)))))
+      ('t (add-hook 'after-init-hook 'init-loader-show-log)))))
 
 (defun init-loader-follow-symlink (dir)
   (cond ((file-symlink-p dir)


### PR DESCRIPTION
[README](https://github.com/emacs-jp/init-loader#init-loader-show-log-after-init--boolean-default-t) describes about `init-loader-show-log-after-init` that "Show log message after initializing if this value is `t`" but current implementation after ccb72c9f62e1271da1518133c6937d85 is the following:
- `(setq init-loader-show-log-after-init t)`
  - `init-loader-show-log` is called
- `(setq init-loader-show-log-after-init nil)`
  - `init-loader-show-log` is called
