### PR TITLE
Fix broken markdown table of platform conventions

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,14 +54,14 @@ the platform.  The following is the list of prefixes and platform
 specific configuration files are loaded in the listed order after
 non-platform specific configuration files.
 
-Platform |  Subplatform       | Prefix         |  Example
----------|--------------------|----------------|-----------------------------
-Windows  |                    | `windows-`     |  windows-fonts.el
-         |  Meadow            | `meadow-`      |  meadow-commands.el
-Mac OS X |  Carbon Emacs      | `carbon-emacs-`|  carbon-emacs-applescript.el
-         |  Cocoa Emacs       | `cocoa-emacs-` |  cocoa-emacs-plist.el
-GNU/Linux|                    | `linux-`       |  linux-commands.el
-All      |  Non-window system | `nw-`          |  nw-key.el
+| Platform  | Subplatform       | Prefix          | Example                     |
+| --------- | ----------------- | --------------- | --------------------------- |
+| Windows   |                   | `windows-`      | windows-fonts.el            |
+|           | Meadow            | `meadow-`       | meadow-commands.el          |
+| Mac OS X  | Carbon Emacs      | `carbon-emacs-` | carbon-emacs-applescript.el |
+|           | Cocoa Emacs       | `cocoa-emacs-`  | cocoa-emacs-plist.el        |
+| GNU/Linux |                   | `linux-`        | linux-commands.el           |
+| All       | Non-window system | `nw-`           | nw-key.el                   |
 
 ### Byte-compilation
 


### PR DESCRIPTION
### Before

<img width="911" alt="2017-07-20 11 26 20" src="https://user-images.githubusercontent.com/473530/28397734-6dc10e9c-6d3e-11e7-981b-f971e36eca87.png">

---

### After

<img width="706" alt="2017-07-20 11 27 06" src="https://user-images.githubusercontent.com/473530/28397739-76220e92-6d3e-11e7-8cb5-607761f53400.png">

