### PR TITLE
modifying to remove warning

### DIFF
--- a/init-loader.el
+++ b/init-loader.el
@@ -180,7 +180,7 @@ example, 00_foo.el, 01_bar.el ... 99_keybinds.el."
 
     (cl-case init-loader-show-log-after-init
       (error-only (add-hook 'after-init-hook 'init-loader--show-log-error-only))
-      ('t (add-hook 'after-init-hook 'init-loader-show-log)))))
+      (t (add-hook 'after-init-hook 'init-loader-show-log)))))
 
 (defun init-loader-follow-symlink (dir)
   (cond ((file-symlink-p dir)


### PR DESCRIPTION
This is a fix to suppress the following warning: This warning appears in emacs 29.2.

> .emacs.d/plugins/init-loader/init-loader.el: Warning: Case 't will match ‘quote’.  If that’s intended, write (t quote) instead.  Otherwise, don’t quote ‘t’.
