### PR TITLE
Fix t/otherwise fallback when init-loader-show-log-after-init is nil

### DIFF
--- a/init-loader.el
+++ b/init-loader.el
@@ -180,7 +180,7 @@ example, 00_foo.el, 01_bar.el ... 99_keybinds.el."
 
     (cl-case init-loader-show-log-after-init
       (error-only (add-hook 'after-init-hook 'init-loader--show-log-error-only))
-      (t (add-hook 'after-init-hook 'init-loader-show-log)))))
+      ('t (add-hook 'after-init-hook 'init-loader-show-log)))))
 
 (defun init-loader-follow-symlink (dir)
   (cond ((file-symlink-p dir)

--- a/test-init-loader.el
+++ b/test-init-loader.el
@@ -113,6 +113,33 @@
       ;; teardown
       (delete-file symlink))))
 
+(ert-deftest init-loader-load ()
+  "Test `init-loader-load'"
+  ;; Test `init-loader-show-log-after-init' switch.
+  (cl-letf (((symbol-function #'directory-files)
+             (lambda (dir &optional full match nosort)
+               init-loader-test-files)))
+    (let ((init-loader-show-log-after-init t)
+          (after-init-hook nil))
+      (init-loader-load "")
+      (should
+       (and (member 'init-loader-show-log after-init-hook)
+            (not (member 'init-loader--show-log-error-only after-init-hook)))))
+
+    (let ((init-loader-show-log-after-init 'error-only)
+          (after-init-hook nil))
+      (init-loader-load "")
+      (should
+       (and (not (member 'init-loader-show-log after-init-hook))
+            (member 'init-loader--show-log-error-only after-init-hook))))
+
+    (let ((init-loader-show-log-after-init nil)
+          (after-init-hook nil))
+      (init-loader-load "")
+      (should
+       (and (not (member 'init-loader-show-log after-init-hook))
+            (not (member 'init-loader--show-log-error-only after-init-hook)))))))
+
 (ert-deftest init-loader-log ()
   "Test for `init-loader-log'"
   ;; pass not string value


### PR DESCRIPTION
This PR fixes the `cl-case` usage error when `init-loader-show-log-after-init` is handled in `init-loader-load`.

Without the quote, `t` as the last case in `cl-case` acts as the fallback when none of earlier cases matches. This bug prevented `nil` for `init-loader-show-log-after-init` to behave similarly to when it is set to `t`, which is unintended. Basically, we were never able to suppress `init-loader-show-log` properly.

Please see the unit tests for the demonstration of correct behaviors. 